### PR TITLE
Add prepare functions and views to handler files

### DIFF
--- a/app/sample/handler/handler_auth_login_logout_post.go
+++ b/app/sample/handler/handler_auth_login_logout_post.go
@@ -9,9 +9,82 @@ import (
 // --------------------------------------------------------------------------
 // POST /auth/logout
 // --------------------------------------------------------------------------
+// Request parameters for handlePostAuthLogout
+type postAuthLogoutRequestParams struct {
+	FlowID string `validate:"omitempty,uuid4"`
+}
+
+// Extract parameters from http request
+func newPostAuthLogoutRequestParams(r *http.Request) *postAuthLogoutRequestParams {
+	return &postAuthLogoutRequestParams{
+		FlowID: r.URL.Query().Get("flow"),
+	}
+}
+
+// Return parameters that can refer in view template
+func (p *postAuthLogoutRequestParams) toViewParams() map[string]any {
+	return map[string]any{
+		"LogoutFlowID": p.FlowID,
+	}
+}
+
+// Validate request parameters and return viewError
+// If you do not want Validation errors to be displayed near input fields,
+// store them in ErrorMessages and return them, so that the errors are displayed anywhere in the template.
+func (p *postAuthLogoutRequestParams) validate() *viewError {
+	viewError := newViewError().extract(pkgVars.validate.Struct(p))
+
+	for k := range viewError.validationFieldErrors {
+		if k == "FlowID" {
+			viewError.messages = append(viewError.messages, newErrorMsg(pkgVars.loc.MustLocalize(&i18n.LocalizeConfig{
+				MessageID: "ERR_FALLBACK",
+			})))
+		}
+	}
+
+	// Individual validations write here that cannot validate in common validations
+
+	return viewError
+}
+
+// Views
+type postAuthLogoutViews struct {
+	index *view
+}
+
+// collect rendering data and validate request parameters.
+func preparePostAuthLogout(w http.ResponseWriter, r *http.Request) (*postAuthLogoutRequestParams, postAuthLogoutViews, *viewError, error) {
+	ctx := r.Context()
+	session := getSession(ctx)
+
+	// collect rendering data
+	baseViewError := newViewError().addMessage(pkgVars.loc.MustLocalize(&i18n.LocalizeConfig{
+		MessageID: "ERR_LOGOUT_DEFAULT",
+	}))
+	reqParams := newPostAuthLogoutRequestParams(r)
+	views := postAuthLogoutViews{
+		index: newView("auth/logout/index.html").addParams(reqParams.toViewParams()),
+	}
+
+	// validate request parameters
+	if viewError := reqParams.validate(); viewError.hasError() {
+		views.index.addParams(viewError.toViewParams()).render(w, r, session)
+		return reqParams, views, baseViewError, fmt.Errorf("validation error: %v", viewError)
+	}
+
+	return reqParams, views, baseViewError, nil
+}
+
 func (p *Provider) handlePostAuthLogout(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	session := getSession(ctx)
+
+	// collect rendering data and validate request parameters.
+	reqParams, views, baseViewError, err := preparePostAuthLogout(w, r)
+	if err != nil {
+		slog.ErrorContext(ctx, "preparePostAuthLogout failed", "err", err)
+		return
+	}
 
 	topIndexView := newView("top/index.html")
 


### PR DESCRIPTION
Add `prepareGetAuthLogin` function and `getAuthLoginViews` struct to `handler_auth_login_get.go`.

* Add `prepareGetAuthLogin` function to collect request parameters and validate them.
* Add `getAuthLoginViews` struct to hold views.
* Update `handleGetAuthLogin` function to use `prepareGetAuthLogin` and `getAuthLoginViews`.

Add `preparePostAuthLogout` function and `postAuthLogoutViews` struct to `handler_auth_login_logout_post.go`.

* Add `preparePostAuthLogout` function to collect request parameters and validate them.
* Add `postAuthLogoutViews` struct to hold views.
* Update `handlePostAuthLogout` function to use `preparePostAuthLogout` and `postAuthLogoutViews`.

Add `prepareGetAuthLoginOidc` function and `getAuthLoginOidcViews` struct to `handler_auth_login_oidc_post.go`.

* Add `prepareGetAuthLoginOidc` function to collect request parameters and validate them.
* Add `getAuthLoginOidcViews` struct to hold views.
* Update `handlePostAuthLoginOidc` function to use `prepareGetAuthLoginOidc` and `getAuthLoginOidcViews`.

Add `prepareGetAuthLoginPasskey` function and `getAuthLoginPasskeyViews` struct to `handler_auth_login_passkey_post.go`.

* Add `prepareGetAuthLoginPasskey` function to collect request parameters and validate them.
* Add `getAuthLoginPasskeyViews` struct to hold views.
* Update `handlePostAuthLoginPasskey` function to use `prepareGetAuthLoginPasskey` and `getAuthLoginPasskeyViews`.

Add `prepareGetAuthLoginPost` function and `getAuthLoginPostViews` struct to `handler_auth_login_post.go`.

* Add `prepareGetAuthLoginPost` function to collect request parameters and validate them.
* Add `getAuthLoginPostViews` struct to hold views.
* Update `handlePostAuthLogin` function to use `prepareGetAuthLoginPost` and `getAuthLoginPostViews`.

Add `prepareGetAuthRecoveryCode` function and `getAuthRecoveryCodeViews` struct to `handler_auth_recovery_code_post.go`.

* Add `prepareGetAuthRecoveryCode` function to collect request parameters and validate them.
* Add `getAuthRecoveryCodeViews` struct to hold views.
* Update `handlePostAuthRecoveryCode` function to use `prepareGetAuthRecoveryCode` and `getAuthRecoveryCodeViews`.

Add `prepareGetAuthRecoveryEmail` function and `getAuthRecoveryEmailViews` struct to `handler_auth_recovery_email_get.go`.

* Add `prepareGetAuthRecoveryEmail` function to collect request parameters and validate them.
* Add `getAuthRecoveryEmailViews` struct to hold views.
* Update `handlePostAuthRecoveryEmail` function to use `prepareGetAuthRecoveryEmail` and `getAuthRecoveryEmailViews`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/YoshinoriSatoh/kratos_example/pull/5?shareId=ac1990a7-a50a-411a-97dd-3108b86707b8).